### PR TITLE
Modifiable inactive StatusIndicator color

### DIFF
--- a/src/controls/Styles/Base/StatusIndicatorStyle.qml
+++ b/src/controls/Styles/Base/StatusIndicatorStyle.qml
@@ -77,6 +77,7 @@ Style {
         readonly property real shineStep: 0.05
         readonly property real smallestAxis: Math.min(control.width, control.height)
         readonly property real outerRecessPercentage: 0.11
+        // HERE
         readonly property color offColor: Qt.rgba(0.13, 0.13, 0.13)
         readonly property color baseColor: control.active ? control.color : offColor
 


### PR DESCRIPTION
From what I know the only way to change the color of the StatusIndicator when it is inactive is to recreate it entirely just to change its color.

So, can you please make it possible to change the color of the _inactive_ StatusIndicator without having to recreate the whole thing?